### PR TITLE
ライブラリバージョンを最新に更新

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,11 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
 
     defaultConfig {
         applicationId "com.katahiromz.krakra_ja_jp"
         minSdkVersion 28
+        //noinspection OldTargetApi
         targetSdkVersion 35
         versionCode 384
         versionName "3.8.4"
@@ -45,25 +46,26 @@ android {
 }
 
 dependencies {
+    //noinspection GradleDependency
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.activity:activity-ktx:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.core:core-ktx:1.17.0'
+    implementation 'androidx.activity:activity-ktx:1.11.0'
 
     // 起動画面表示用。
-    implementation 'androidx.core:core-splashscreen:1.2.0-alpha01'
+    implementation 'androidx.core:core-splashscreen:1.2.0-rc01'
 
     // レイアウト管理用。
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
 
     // ダイアログ表示用。
-    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'com.google.android.material:material:1.13.0'
 
     // ログ出力用：Timber
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
     // テスト用。
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        agp_version = '8.10.1'
+        agp_version = '8.13.0'
     }
-    ext.kotlin_version = '1.9.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### 背景

- ライブラリバージョンが古いため、互換性が低いAPIが内部で呼ばれており、パフォーマンスの悪化を招いている可能性がある

### 対応

- ライブラリのバージョンを最新に更新

### 影響範囲

- パフォーマンスが改善する可能性
- メモリ使用量が改善する可能性
- 過去バージョンで起きるバグの再現有無