### PR TITLE
StrictModeをDebugビルド時のみ利用する形に修正

### DIFF
--- a/app/src/main/java/com/katahiromz/krakra_ja_jp/MainActivity.kt
+++ b/app/src/main/java/com/katahiromz/krakra_ja_jp/MainActivity.kt
@@ -252,17 +252,7 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
     override fun onCreate(savedInstanceState: Bundle?) {
         Timber.i("onCreate")
 
-        // 様々なチェックを追加。
-        StrictMode.setThreadPolicy(
-            StrictMode.ThreadPolicy.Builder()
-                .detectAll()
-                .build()
-        )
-        StrictMode.setVmPolicy(
-            StrictMode.VmPolicy.Builder()
-                .detectAll()
-                .build()
-        )
+        setStrictMode()
 
         // おまじない。
         window.attributes.layoutInDisplayCutoutMode =
@@ -703,5 +693,23 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
         // vibrator が null であれば何もしない
         vibrator?.cancel()
         oldVibratorLength = 0
+    }
+
+    /////////////////////////////////////////////////////////////////////
+    // その他の設定
+
+    private fun setStrictMode() {
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectAll()
+                    .build()
+            )
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder()
+                    .detectAll()
+                    .build()
+            )
+        }
     }
 }


### PR DESCRIPTION
### 背景

- StrictModeは通常より厳密に問題を検出するためのモードであるが、リリースビルド時にも有効になっていたため、デバッグ時のみ利用される形に修正した
  - StrictMode.ThreadPolicy は、スレッドに関連する潜在的な問題を検出するために使用されます。
  - StrictMode.VmPolicy は、**VM (仮想マシン)**全体に関連する潜在的な問題を検出するために使用されます。

### 対応

- StrictModeの設定が複数存在していたので、メソッドにまとめた
- メソッドにて、BuildConfig.DEBUGが有効な場合のみ設定が行われるようにした

### 影響範囲

- リリース版でのパフォーマンス改善の可能性