### PR TITLE
regionコメントを追加

### DIFF
--- a/app/src/main/java/com/katahiromz/krakra_ja_jp/MainActivity.kt
+++ b/app/src/main/java/com/katahiromz/krakra_ja_jp/MainActivity.kt
@@ -48,7 +48,7 @@ fun Context.createLocalizedContext(locale: Locale): Context {
 }
 
 /////////////////////////////////////////////////////////////////////
-// region 定数。
+// region 定数
 
 // トーストの種類 (showToast用)
 const val SHORT_TOAST = 0

--- a/app/src/main/java/com/katahiromz/krakra_ja_jp/MainActivity.kt
+++ b/app/src/main/java/com/katahiromz/krakra_ja_jp/MainActivity.kt
@@ -48,7 +48,7 @@ fun Context.createLocalizedContext(locale: Locale): Context {
 }
 
 /////////////////////////////////////////////////////////////////////
-// 定数。
+// region 定数。
 
 // トーストの種類 (showToast用)
 const val SHORT_TOAST = 0
@@ -60,9 +60,11 @@ const val LONG_SNACK = 1
 const val ACTION_SNACK_OK = 2
 // TODO: Add more snack
 
+// endregion
+
 class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.OnInitListener {
     /////////////////////////////////////////////////////////////////////
-    // 共通
+    // region 共通
 
     // デバッグログにTimberを使用する。
     private fun initTimber() {
@@ -157,8 +159,10 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
         super.onWindowFocusChanged(hasFocus)
     }
 
+    // endregion
+
     /////////////////////////////////////////////////////////////////////
-    // パーミッション関連
+    // region パーミッション関連
     // 参考：https://qiita.com/sokume2106/items/46bd286569a6e7fac43d
 
     private val audioRecordingPermissionChecker =
@@ -245,8 +249,10 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
         }
     }
 
+    // endregion
+
     /////////////////////////////////////////////////////////////////////
-    // イベントハンドラ関連
+    // region イベントハンドラ関連
 
     // アクティビティの作成時。
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -394,8 +400,10 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
     }
     private var resultString = ""
 
+    // endregion
+
     /////////////////////////////////////////////////////////////////////
-    // WebView関連
+    // region WebView関連
 
     // ウェブビュー オブジェクト。
     private var webView: WebView? = null
@@ -530,9 +538,11 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
         return "(unknown version)"
     }
 
+    // endregion
+
     /////////////////////////////////////////////////////////////////////
-    // ロケール関連
-    //
+    // region ロケール関連
+
     private var currLocale: Locale = Locale.ENGLISH
     var currLocaleContext: Context? = null
 
@@ -566,9 +576,11 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
         return getLocString(id, currLocale)
     }
 
+    // endregion
+
     /////////////////////////////////////////////////////////////////////
-    // TextToSpeech関連
-    //
+    // region TextToSpeech関連
+
     private var tts: TextToSpeech? = null // TextToSpeechオブジェクト。
     private var isSpeechReady = false // スピーチの準備が完了したか？
     private var theText = "" // スピーチテキスト。
@@ -614,8 +626,10 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
         }
     }
 
+    // endregion
+
     /////////////////////////////////////////////////////////////////////
-    // 振動関連
+    // region 振動関連
 
     private var hasVibratorInitialized: Boolean = false // 初期化成功フラグ
     private var oldVibratorLength: Int = 0
@@ -695,8 +709,10 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
         oldVibratorLength = 0
     }
 
+    // endregion
+
     /////////////////////////////////////////////////////////////////////
-    // その他の設定
+    // region その他の設定
 
     private fun setStrictMode() {
         if (BuildConfig.DEBUG) {
@@ -712,4 +728,6 @@ class MainActivity : AppCompatActivity(), ValueCallback<String>, TextToSpeech.On
             )
         }
     }
+
+    // endregion
 }


### PR DESCRIPTION
### 背景

- 一つのファイルに多数のカテゴリのリソースが含まれている
- 別ファイルに分けるのもありだが、直近の対応としてリソースをregionコメントで区切る形とした
  - 元々の章節コメントの区切りに沿って行う形とした

### 対応

- `//////////` で区切られる部分の前後に region ~ endregion コメントを追記した
  - これにより、Structureウィンドウにてカテゴリ毎に整理される形となる

<img width="298" height="349" alt="Screenshot 2025-09-13 at 15 27 17" src="https://github.com/user-attachments/assets/1a405207-4d14-4d85-a135-ff5cbc9d83ac" />
