### PR TITLE
Localeのwarningを修正

### DIFF
--- a/app/src/main/java/com/katahiromz/krakra_ja_jp/MyWebChromeClient.kt
+++ b/app/src/main/java/com/katahiromz/krakra_ja_jp/MyWebChromeClient.kt
@@ -134,10 +134,16 @@ class MyWebChromeClient(private var activity: MainActivity?, private val listene
                 locale = Locale.GERMAN
             }
             "es", "es-ES" -> { // Spanish
-                locale = Locale("es", "ES");
+                locale = Locale.Builder()
+                    .setLanguage("es")
+                    .setRegion("ES")
+                    .build()
             }
             "ru", "ru-RU" -> { // Russian
-                locale = Locale("ru", "RU");
+                locale = Locale.Builder()
+                    .setLanguage("ru")
+                    .setRegion("RU")
+                    .build()
             }
             else -> { // English is default
                 locale = Locale.ENGLISH


### PR DESCRIPTION
### 修正対象

```
w: file:///C:/dev/Saimin/KraKra_ja_jp/app/src/main/java/com/katahiromz/krakra_ja_jp/MyWebChromeClient.kt:137:26 'constructor(p0: String!, p1: String!): Locale' is deprecated. Deprecated in Java.
w: file:///C:/dev/Saimin/KraKra_ja_jp/app/src/main/java/com/katahiromz/krakra_ja_jp/MyWebChromeClient.kt:140:26 'constructor(p0: String!, p1: String!): Locale' is deprecated. Deprecated in Java.
```

### 修正内容

- Locale.Builderを利用

### 動作確認

- 修正後にスペイン語とロシア語の設定を行い、問題ないことを確認

https://github.com/user-attachments/assets/fbdc6735-dc41-4ff4-b607-12941ca1c3f8
